### PR TITLE
Read profile and key from `_FILE` secrets

### DIFF
--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -52,28 +52,12 @@ func init() {
 	var err error
 	Profile, err = initSecret("NEXTDNS_PROFILE")
 	if err != nil {
-		Log.Error(err)
+		Log.Error(err.Error())
 		os.Exit(1)
 	}
 	APIKey, err = initSecret("NEXTDNS_API_KEY")
 	if err != nil {
-		Log.Error(err)
+		Log.Error(err.Error())
 		os.Exit(1)
 	}
-}
-
-func initSecret(prefix string) (string, error) {
-	key, ok := os.LookupEnv(prefix)
-	if ok {
-		return key, nil
-	}
-	file, ok := os.LookupEnv(fmt.Sprintf("%s_FILE", prefix)
-	if !ok {
-		return "", fmt.Errorf("%s or %s_FILE must be set", prefix, prefix)
-	}
-	raw, err := os.ReadFile(file)
-	if err != nil {
-		return "", fmt.Errorf("read %s: %w", APIKeyFile, err)
-	}
-	return raw, nil
 }

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -49,15 +49,31 @@ func init() {
 	ResultLimit = DefaultEnv("NEXTDNS_RESULT_LIMIT", "50")
 
 	// Required configuration.
-	var set bool
-	Profile, set = os.LookupEnv("NEXTDNS_PROFILE")
-	if !set {
-		Log.Error("NEXTDNS_PROFILE must be set")
+	var err error
+	Profile, err = initSecret("NEXTDNS_PROFILE")
+	if err != nil {
+		Log.Error(err)
 		os.Exit(1)
 	}
-	APIKey, set = os.LookupEnv("NEXTDNS_API_KEY")
-	if !set {
-		Log.Error("NEXTDNS_API_KEY must be set")
+	APIKey, err = initSecret("NEXTDNS_API_KEY")
+	if err != nil {
+		Log.Error(err)
 		os.Exit(1)
 	}
+}
+
+func initSecret(prefix string) (string, error) {
+	key, ok := os.LookupEnv(prefix)
+	if ok {
+		return key, nil
+	}
+	file, ok := os.LookupEnv(fmt.Sprintf("%s_FILE", prefix)
+	if !ok {
+		return "", fmt.Errorf("%s or %s_FILE must be set", prefix, prefix)
+	}
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", APIKeyFile, err)
+	}
+	return raw, nil
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"fmt"
 	"os"
+	"strings"
 )
 
 // Return the value of an environment variable,
@@ -12,4 +14,21 @@ func DefaultEnv(key, usual string) string {
 		return usual
 	}
 	return value
+}
+
+// initSecret returns secret either from env variable or from a file
+func initSecret(prefix string) (string, error) {
+	key, ok := os.LookupEnv(prefix)
+	if ok {
+		return key, nil
+	}
+	file, ok := os.LookupEnv(fmt.Sprintf("%s_FILE", prefix))
+	if !ok {
+		return "", fmt.Errorf("%s or %s_FILE must be set", prefix, prefix)
+	}
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("read %s_FILE: %w", prefix, err)
+	}
+	return strings.TrimSpace(string(raw)), nil
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -13,5 +14,30 @@ func TestDefaultEnv(t *testing.T) {
 	}
 	if DefaultEnv("BAR", "baz") != "baz" {
 		t.Error("expected to get `baz`")
+	}
+}
+
+func TestInitSecret(t *testing.T) {
+	os.Setenv("BAZ", "1223")
+	v, err := initSecret("BAZ")
+	if err != nil {
+		t.Errorf("expected no error: %s", err)
+	}
+	if v != "1223" {
+		t.Errorf("expected 1223: %s", v)
+	}
+
+	f := filepath.Join(t.TempDir(), "boz")
+	err = os.WriteFile(f, []byte("345"), 0o755)
+	if err != nil {
+		t.Errorf("expected no error: %s", err)
+	}
+	os.Setenv("BOZ_FILE", f)
+	v, err = initSecret("BOZ")
+	if err != nil {
+		t.Errorf("expected no error: %s", err)
+	}
+	if v != "345" {
+		t.Errorf("expected 345: %s", v)
 	}
 }


### PR DESCRIPTION
See https://docs.docker.com/engine/swarm/secrets/#advanced-example-use-secrets-with-a-wordpress-service

tests:
```
NEXTDNS_PROFILE=... NEXTDNS_API_KEY=... go test ./...
?       github.com/raylas/nextdns-exporter      [no test files]
ok      github.com/raylas/nextdns-exporter/internal/api (cached)
ok      github.com/raylas/nextdns-exporter/internal/util        0.150s
```

tested via:
```
NEXTDNS_PROFILE_FILE=../nextdns/profile NEXTDNS_API_KEY_FILE=../nextdns/api go run .
```